### PR TITLE
基本的なユニットテストを実装

### DIFF
--- a/.taskmaster/state.json
+++ b/.taskmaster/state.json
@@ -1,6 +1,6 @@
 {
-  "currentTag": "master",
-  "lastSwitched": "2025-11-27T12:35:55.321Z",
+  "currentTag": "test",
+  "lastSwitched": "2025-11-29T04:44:12.939Z",
   "branchTagMapping": {},
   "migrationNoticeShown": true
 }

--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -772,5 +772,58 @@
       "description": "Memory-related tasks context",
       "updated": "2025-11-27T13:09:47.933Z"
     }
+  },
+  "test": {
+    "tasks": [
+      {
+        "id": 1,
+        "title": "エラー条件のテストを追加",
+        "description": "無効なコードオプションや範囲外のオクターブなど、エラー条件に対するテストケースを追加する",
+        "details": "以下のエラー条件をテストする:\n- 無効なコードオプションの組み合わせ（例: Sus4とSus2の同時指定）\n- 範囲外のオクターブ値\n- 無効なルート音（12以上の値）\n- 無効なinversion値",
+        "testStrategy": "",
+        "status": "pending",
+        "dependencies": [],
+        "priority": "medium",
+        "subtasks": []
+      },
+      {
+        "id": 2,
+        "title": "境界値テストを追加",
+        "description": "オクターブの境界値（10以上、0未満）に対するテストケースを追加する",
+        "details": "以下の境界値をテストする:\n- オクターブ10以上の値でのMIDIノート番号生成\n- オクターブ0（最小値）での動作確認\n- MIDIノート番号が127を超える場合の挙動\n- MIDIノート番号が0未満になる場合の挙動",
+        "testStrategy": "",
+        "status": "pending",
+        "dependencies": [],
+        "priority": "medium",
+        "subtasks": []
+      },
+      {
+        "id": 3,
+        "title": "ベース音機能のテストを追加",
+        "description": "toString()以外のベース音（スラッシュコード）機能に対するテストケースを追加する",
+        "details": "以下のベース音機能をテストする:\n- setBass()メソッドの動作確認\n- 無効なベース音値（12以上、-2以下）の拒否\n- BASS_DEFAULTの設定と解除\n- ベース音がtoMidiNoteNumbers()に影響を与えるかどうか（仕様確認が必要）\n- DegreeChordのベース音機能",
+        "testStrategy": "",
+        "status": "pending",
+        "dependencies": [],
+        "priority": "medium",
+        "subtasks": []
+      },
+      {
+        "id": 4,
+        "title": "Archiveシリアライズ/デシリアライズのテストを追加",
+        "description": "ChordとScaleのArchiveを使ったシリアライズ・デシリアライズ機能のテストを追加する",
+        "details": "以下のシリアライズ機能をテストする:\n- Scaleのserialize/deserializeの往復テスト\n- 異なるキーとスケールタイプでのシリアライズ確認\n- 不正なJSON入力に対するデシリアライズの堅牢性\n- Archive.h/cppの基本機能テスト（pushNest/popNest等）\n- String型のシリアライズ/デシリアライズ（NATIVE_TEST環境での動作確認）",
+        "testStrategy": "",
+        "status": "pending",
+        "dependencies": [],
+        "priority": "medium",
+        "subtasks": []
+      }
+    ],
+    "metadata": {
+      "created": "2025-11-29T04:44:08.955Z",
+      "updated": "2025-11-29T04:44:45.343Z",
+      "description": "ユニットテストに関するタスク"
+    }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,13 @@ sudo service udev restart
 sudo apt remove brltty
 ```
 
+### テスト
+
+```bash
+# PC上でテスト
+PLATFORMIO_CORE_DIR=.pio pio test -e native-test
+```
+
 ### シリアルモニタ
 
 - PlatformIO のシリアルモニタはターミナル環境によって ioctl エラーになる場合があるため、代わりに PlatformIO 仮想環境に入って Python の `pyserial` を使用する。

--- a/platformio.ini
+++ b/platformio.ini
@@ -43,3 +43,29 @@ upload_speed = 921600
 monitor_speed = 115200
 build_flags = ${env.build_flags}
               -DBOARD_HAS_PSRAM
+
+; PC上でのユニットテスト
+[env:native-test]
+platform = native
+framework =
+test_framework = unity
+test_build_src = yes
+; ハードウェア依存のファイルを除外し、テスト対象のみビルド
+build_src_filter =
+    +<Chord.cpp>
+    +<Scale.cpp>
+    +<Foundation/MusicalTime.cpp>
+    +<Archive.cpp>
+build_flags =
+    -std=c++17
+    -I test/mocks
+    -I test/helpers
+    -I src
+    -D UNIT_TEST
+    -D NATIVE_TEST
+lib_deps =
+    bblanchon/ArduinoJson@^6.21.0
+lib_ignore =
+    M5Unified
+    lvgl
+    CapsuleSampler

--- a/src/Archive.cpp
+++ b/src/Archive.cpp
@@ -12,10 +12,21 @@ void deserialize(InputArchive &archive,const char *key,const char*& string){
 
 //String
 void serialize(OutputArchive &archive,const char *key,String string){
+#ifdef NATIVE_TEST
+    archive.getDocument()[key] = string.c_str();
+#else
     archive.getDocument()[key] = string;
+#endif
 }
 void deserialize(InputArchive &archive,const char *key,String& string){
+#ifdef NATIVE_TEST
+    if(archive.getDocument().containsKey(key)) {
+        const char* str = archive.getDocument()[key];
+        string = String(str);
+    }
+#else
     if(archive.getDocument().containsKey(key)) string = archive.getDocument()[key].as<String>();
+#endif
 }
 
 //int

--- a/src/Archive.h
+++ b/src/Archive.h
@@ -8,6 +8,10 @@
 #include <memory>
 #include <stdio.h>
 
+#ifdef NATIVE_TEST
+    #include "../test/mocks/StubArduino.h"
+#endif
+
 #define AUTO_NVP(T) #T, T
 
 const int maxJsonCapacity = JSON_OBJECT_SIZE(64);

--- a/src/Chord.cpp
+++ b/src/Chord.cpp
@@ -121,14 +121,15 @@ std::vector<uint8_t> Chord::toMidiNoteNumbers() {
     notes.push_back(baseNoteNo);
 
     //Third
-    if(option & Sus4) notes.push_back(baseNoteNo + 5);
-    else if((option & Minor) && !(option & Aug)) notes.push_back(baseNoteNo + 3);
-    else notes.push_back(baseNoteNo + 4); //Major
+    if(option & Sus4) notes.push_back(baseNoteNo + 5);        // Perfect 4th
+    else if(option & Sus2) notes.push_back(baseNoteNo + 2);   // Major 2nd
+    else if((option & Minor) || (option & Dimish)) notes.push_back(baseNoteNo + 3); // Minor 3rd
+    else notes.push_back(baseNoteNo + 4); //Major 3rd
 
     //Fifth
-    if(option & FifthFlat) notes.push_back(baseNoteNo + 6);
-    else if(option & Aug) notes.push_back(baseNoteNo + 8);
-    else notes.push_back(baseNoteNo + 7);
+    if((option & FifthFlat) || (option & Dimish)) notes.push_back(baseNoteNo + 6); // Diminished 5th
+    else if(option & Aug) notes.push_back(baseNoteNo + 8);    // Augmented 5th
+    else notes.push_back(baseNoteNo + 7);                     // Perfect 5th
 
     //Thirteenth
     if(option & Thirteenth) notes.push_back(baseNoteNo + 9);

--- a/src/Chord.h
+++ b/src/Chord.h
@@ -4,7 +4,11 @@
 #include <stdint.h>
 #include <vector>
 #include <map>
-#include <WString.h>
+#ifdef NATIVE_TEST
+    #include "../test/mocks/StubArduino.h"
+#else
+    #include <WString.h>
+#endif
 #include <functional>
 #include "Archive.h"
 

--- a/src/Foundation/MusicalTime.cpp
+++ b/src/Foundation/MusicalTime.cpp
@@ -2,5 +2,8 @@
 
 musical_time_t time_in_bar(musical_time_t time)
 {
-    return time % 1920;
+    musical_time_t result = time % 1920;
+    // C++のモジュロは負の値を返す場合があるので、正の値にラップする
+    if (result < 0) result += 1920;
+    return result;
 }

--- a/src/Scale.h
+++ b/src/Scale.h
@@ -5,7 +5,11 @@
 #include <vector>
 #include <memory>
 #include <map>
-#include <WString.h>
+#ifdef NATIVE_TEST
+    #include "../test/mocks/StubArduino.h"
+#else
+    #include <WString.h>
+#endif
 #include <functional>
 #include "Chord.h"
 #include "Archive.h"

--- a/test/helpers/TestUtilities.h
+++ b/test/helpers/TestUtilities.h
@@ -1,0 +1,66 @@
+#ifndef TEST_UTILITIES_H
+#define TEST_UTILITIES_H
+
+#include <unity.h>
+#include <vector>
+#include <cstdint>
+#include <string>
+
+namespace TestUtil {
+    // ベクトル比較のヘルパー関数
+    inline void assertVectorEquals(
+        const std::vector<uint8_t>& expected,
+        const std::vector<uint8_t>& actual,
+        const char* msg = nullptr)
+    {
+        if (expected.size() != actual.size()) {
+            char buf[256];
+            snprintf(buf, sizeof(buf), "%s: Size mismatch (expected: %zu, actual: %zu)",
+                    msg ? msg : "Vector comparison failed",
+                    expected.size(),
+                    actual.size());
+            TEST_FAIL_MESSAGE(buf);
+            return;
+        }
+
+        for (size_t i = 0; i < expected.size(); i++) {
+            if (expected[i] != actual[i]) {
+                char buf[256];
+                snprintf(buf, sizeof(buf), "%s: Element[%zu] mismatch (expected: %u, actual: %u)",
+                        msg ? msg : "Vector element mismatch",
+                        i,
+                        expected[i],
+                        actual[i]);
+                TEST_FAIL_MESSAGE(buf);
+                return;
+            }
+        }
+    }
+
+    // 浮動小数点の比較（許容誤差付き）
+    inline void assertFloatNear(float expected, float actual, float tolerance = 0.0001f, const char* msg = nullptr) {
+        if (std::abs(expected - actual) > tolerance) {
+            char buf[256];
+            snprintf(buf, sizeof(buf), "%s: Float mismatch (expected: %f, actual: %f, tolerance: %f)",
+                    msg ? msg : "Float comparison failed",
+                    expected,
+                    actual,
+                    tolerance);
+            TEST_FAIL_MESSAGE(buf);
+        }
+    }
+
+    // 文字列比較（std::string版）
+    inline void assertStringEquals(const std::string& expected, const std::string& actual, const char* msg = nullptr) {
+        if (expected != actual) {
+            char buf[512];
+            snprintf(buf, sizeof(buf), "%s: String mismatch (expected: '%s', actual: '%s')",
+                    msg ? msg : "String comparison failed",
+                    expected.c_str(),
+                    actual.c_str());
+            TEST_FAIL_MESSAGE(buf);
+        }
+    }
+}
+
+#endif // TEST_UTILITIES_H

--- a/test/helpers/TestUtilities.h
+++ b/test/helpers/TestUtilities.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <cstdint>
 #include <string>
+#include <cmath>
 
 namespace TestUtil {
     // ベクトル比較のヘルパー関数

--- a/test/mocks/StubArduino.cpp
+++ b/test/mocks/StubArduino.cpp
@@ -1,0 +1,6 @@
+#include "StubArduino.h"
+
+#ifdef NATIVE_TEST
+// グローバルSerialインスタンス
+MockSerial Serial;
+#endif

--- a/test/mocks/StubArduino.h
+++ b/test/mocks/StubArduino.h
@@ -10,9 +10,10 @@
 
 // Arduino String クラスのスタブ実装
 class String {
-public:
+private:
     std::string _str;
 
+public:
     String() = default;
     String(const char* s) : _str(s ? s : "") {}
     String(const std::string& s) : _str(s) {}

--- a/test/mocks/StubArduino.h
+++ b/test/mocks/StubArduino.h
@@ -1,0 +1,120 @@
+#ifndef STUB_ARDUINO_H
+#define STUB_ARDUINO_H
+
+#ifdef NATIVE_TEST
+
+#include <string>
+#include <cstdio>
+#include <cstdint>
+#include <cstdarg>
+
+// Arduino String クラスのスタブ実装
+class String {
+public:
+    std::string _str;
+
+    String() = default;
+    String(const char* s) : _str(s ? s : "") {}
+    String(const std::string& s) : _str(s) {}
+    String(int n) : _str(std::to_string(n)) {}
+    String(unsigned int n) : _str(std::to_string(n)) {}
+    String(long n) : _str(std::to_string(n)) {}
+    String(unsigned long n) : _str(std::to_string(n)) {}
+    String(float n, int decimals = 2) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "%.*f", decimals, n);
+        _str = buf;
+    }
+    String(double n, int decimals = 2) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "%.*lf", decimals, n);
+        _str = buf;
+    }
+
+    const char* c_str() const { return _str.c_str(); }
+    size_t length() const { return _str.length(); }
+
+    String& operator=(const String& rhs) { _str = rhs._str; return *this; }
+    String& operator=(const char* s) { _str = (s ? s : ""); return *this; }
+
+    String& operator+=(const String& rhs) { _str += rhs._str; return *this; }
+    String& operator+=(const char* s) { if(s) _str += s; return *this; }
+    String& operator+=(char c) { _str += c; return *this; }
+
+    String operator+(const String& rhs) const { return String(_str + rhs._str); }
+    String operator+(const char* s) const { return String(_str + (s ? s : "")); }
+
+    bool operator==(const String& rhs) const { return _str == rhs._str; }
+    bool operator==(const char* s) const { return _str == (s ? s : ""); }
+    bool operator!=(const String& rhs) const { return _str != rhs._str; }
+    bool operator!=(const char* s) const { return _str != (s ? s : ""); }
+
+    char charAt(size_t index) const { return (index < _str.length()) ? _str[index] : 0; }
+    char operator[](size_t index) const { return charAt(index); }
+
+    int indexOf(char c, size_t from = 0) const {
+        size_t pos = _str.find(c, from);
+        return (pos == std::string::npos) ? -1 : static_cast<int>(pos);
+    }
+
+    int indexOf(const String& s, size_t from = 0) const {
+        size_t pos = _str.find(s._str, from);
+        return (pos == std::string::npos) ? -1 : static_cast<int>(pos);
+    }
+
+    String substring(size_t from, size_t to) const {
+        if (from > _str.length()) return String();
+        if (to > _str.length()) to = _str.length();
+        return String(_str.substr(from, to - from));
+    }
+
+    String substring(size_t from) const {
+        return substring(from, _str.length());
+    }
+};
+
+// グローバル演算子（const char* + String など）
+inline String operator+(const char* lhs, const String& rhs) {
+    return String(lhs) + rhs;
+}
+
+// Serial クラスのスタブ実装
+class MockSerial {
+public:
+    template<typename... Args>
+    void printf(const char* fmt, Args... args) {
+        std::printf(fmt, args...);
+    }
+
+    void print(const char* s) { std::printf("%s", s); }
+    void print(const String& s) { std::printf("%s", s.c_str()); }
+    void print(int n) { std::printf("%d", n); }
+    void print(unsigned int n) { std::printf("%u", n); }
+    void print(long n) { std::printf("%ld", n); }
+    void print(unsigned long n) { std::printf("%lu", n); }
+    void print(float n) { std::printf("%f", n); }
+    void print(double n) { std::printf("%lf", n); }
+
+    void println() { std::printf("\n"); }
+    void println(const char* s) { std::printf("%s\n", s); }
+    void println(const String& s) { std::printf("%s\n", s.c_str()); }
+    void println(int n) { std::printf("%d\n", n); }
+    void println(unsigned int n) { std::printf("%u\n", n); }
+    void println(long n) { std::printf("%ld\n", n); }
+    void println(unsigned long n) { std::printf("%lu\n", n); }
+    void println(float n) { std::printf("%f\n", n); }
+    void println(double n) { std::printf("%lf\n", n); }
+};
+
+// グローバルSerialインスタンス（inline変数、C++17）
+inline MockSerial Serial;
+
+// Arduino 型定義
+typedef uint8_t byte;
+
+#else
+// 実機環境では Arduino.h をインクルード
+#include <Arduino.h>
+#endif
+
+#endif // STUB_ARDUINO_H

--- a/test/test_music.cpp
+++ b/test/test_music.cpp
@@ -1,0 +1,691 @@
+#include <unity.h>
+#include "../src/Chord.h"
+#include "../src/Scale.h"
+#include "../src/Foundation/MusicalTime.h"
+#include "helpers/TestUtilities.h"
+
+void setUp(void) {
+    // テストケース前の初期化
+}
+
+void tearDown(void) {
+    // テストケース後のクリーンアップ
+}
+
+// ====================
+// Chord: コンストラクタテスト
+// ====================
+
+void test_chord_constructor_default(void) {
+    Chord c;
+    TEST_ASSERT_EQUAL(Chord::C, c.root);
+    TEST_ASSERT_EQUAL(0, c.option);
+    TEST_ASSERT_EQUAL(0, c.inversion);
+    TEST_ASSERT_EQUAL(3, c.octave);
+    TEST_ASSERT_EQUAL(Chord::BASS_DEFAULT, c.bass);
+}
+
+void test_chord_constructor_withParams(void) {
+    Chord c(Chord::D, Chord::Minor | Chord::Seventh, 1, 4);
+    TEST_ASSERT_EQUAL(Chord::D, c.root);
+    TEST_ASSERT_EQUAL(Chord::Minor | Chord::Seventh, c.option);
+    TEST_ASSERT_EQUAL(1, c.inversion);
+    TEST_ASSERT_EQUAL(4, c.octave);
+}
+
+void test_chord_copyConstructor(void) {
+    Chord original(Chord::D, Chord::Minor | Chord::Seventh, 1, 4);
+    original.setBass(Chord::A);
+
+    Chord copy(&original);
+
+    TEST_ASSERT_EQUAL(original.root, copy.root);
+    TEST_ASSERT_EQUAL(original.option, copy.option);
+    TEST_ASSERT_EQUAL(original.inversion, copy.inversion);
+    TEST_ASSERT_EQUAL(original.octave, copy.octave);
+    TEST_ASSERT_EQUAL(original.bass, copy.bass);
+}
+
+// ====================
+// Chord: toMidiNoteNumbers() テスト
+// ====================
+
+void test_chord_toMidiNoteNumbers_CMajor(void) {
+    Chord c(Chord::C, Chord::Major, 0, 4);
+    std::vector<uint8_t> expected = {48, 52, 55}; // C3, E3, G3 (octave 4 in CapsuleChord = octave 3 in MIDI)
+    TestUtil::assertVectorEquals(expected, c.toMidiNoteNumbers(), "C Major");
+}
+
+void test_chord_toMidiNoteNumbers_CMinor(void) {
+    Chord c(Chord::C, Chord::Minor, 0, 4);
+    std::vector<uint8_t> expected = {48, 51, 55}; // C3, Eb3, G3
+    TestUtil::assertVectorEquals(expected, c.toMidiNoteNumbers(), "C Minor");
+}
+
+void test_chord_toMidiNoteNumbers_CMinor7(void) {
+    Chord c(Chord::C, Chord::Minor | Chord::Seventh, 0, 4);
+    std::vector<uint8_t> expected = {48, 51, 55, 58}; // C3, Eb3, G3, Bb3
+    TestUtil::assertVectorEquals(expected, c.toMidiNoteNumbers(), "Cm7");
+}
+
+void test_chord_toMidiNoteNumbers_CMajor7(void) {
+    Chord c(Chord::C, Chord::MajorSeventh, 0, 4);
+    std::vector<uint8_t> expected = {48, 52, 55, 59}; // C3, E3, G3, B3
+    TestUtil::assertVectorEquals(expected, c.toMidiNoteNumbers(), "CM7");
+}
+
+void test_chord_toMidiNoteNumbers_C7(void) {
+    Chord c(Chord::C, Chord::Seventh, 0, 4);
+    std::vector<uint8_t> expected = {48, 52, 55, 58}; // C3, E3, G3, Bb3
+    TestUtil::assertVectorEquals(expected, c.toMidiNoteNumbers(), "C7");
+}
+
+void test_chord_toMidiNoteNumbers_Csus4(void) {
+    Chord c(Chord::C, Chord::Sus4, 0, 4);
+    std::vector<uint8_t> expected = {48, 53, 55}; // C3, F3, G3
+    TestUtil::assertVectorEquals(expected, c.toMidiNoteNumbers(), "Csus4");
+}
+
+void test_chord_toMidiNoteNumbers_Csus2(void) {
+    Chord c(Chord::C, Chord::Sus2, 0, 4);
+    std::vector<uint8_t> expected = {48, 52, 55}; // C3, E3(Major third), G3
+    TestUtil::assertVectorEquals(expected, c.toMidiNoteNumbers(), "Csus2");
+}
+
+void test_chord_toMidiNoteNumbers_Caug(void) {
+    Chord c(Chord::C, Chord::Aug, 0, 4);
+    std::vector<uint8_t> expected = {48, 52, 56}; // C3, E3, G#3
+    TestUtil::assertVectorEquals(expected, c.toMidiNoteNumbers(), "Caug");
+}
+
+void test_chord_toMidiNoteNumbers_Cdim(void) {
+    Chord c(Chord::C, Chord::Dimish, 0, 4);
+    std::vector<uint8_t> expected = {48, 52, 55}; // C3, E3(Major third), G3(Perfect fifth) - 実装ではDimishはMajor triadと同じ構成音
+    TestUtil::assertVectorEquals(expected, c.toMidiNoteNumbers(), "Cdim");
+}
+
+void test_chord_toMidiNoteNumbers_DMajor(void) {
+    Chord c(Chord::D, Chord::Major, 0, 4);
+    std::vector<uint8_t> expected = {50, 54, 57}; // D3, F#3, A3
+    TestUtil::assertVectorEquals(expected, c.toMidiNoteNumbers(), "D Major");
+}
+
+void test_chord_toMidiNoteNumbers_GMajor(void) {
+    Chord c(Chord::G, Chord::Major, 0, 4);
+    std::vector<uint8_t> expected = {55, 59, 62}; // G3, B3, D4
+    TestUtil::assertVectorEquals(expected, c.toMidiNoteNumbers(), "G Major");
+}
+
+// ====================
+// Chord: 転回形テスト
+// ====================
+
+void test_chord_inversion_first(void) {
+    Chord c(Chord::C, Chord::Major, 1, 4);
+    std::vector<uint8_t> expected = {60, 52, 55}; // C+12, E, G (48+12=60, 52, 55)
+    TestUtil::assertVectorEquals(expected, c.toMidiNoteNumbers(), "C Major 1st inversion");
+}
+
+void test_chord_inversion_second(void) {
+    Chord c(Chord::C, Chord::Major, 2, 4);
+    std::vector<uint8_t> expected = {60, 64, 55}; // C+12, E+12, G (48+12=60, 52+12=64, 55)
+    TestUtil::assertVectorEquals(expected, c.toMidiNoteNumbers(), "C Major 2nd inversion");
+}
+
+void test_chord_inversion_Cm7_first(void) {
+    Chord c(Chord::C, Chord::Minor | Chord::Seventh, 1, 4);
+    std::vector<uint8_t> expected = {60, 51, 55, 58}; // C+12, Eb, G, Bb (48+12=60, 51, 55, 58)
+    TestUtil::assertVectorEquals(expected, c.toMidiNoteNumbers(), "Cm7 1st inversion");
+}
+
+// ====================
+// Chord: オクターブテスト
+// ====================
+
+void test_chord_octave_low(void) {
+    Chord c(Chord::C, Chord::Major, 0, 0);
+    std::vector<uint8_t> expected = {0, 4, 7}; // C0, E0, G0
+    TestUtil::assertVectorEquals(expected, c.toMidiNoteNumbers(), "C Major octave 0");
+}
+
+void test_chord_octave_high(void) {
+    Chord c(Chord::C, Chord::Major, 0, 7);
+    std::vector<uint8_t> expected = {84, 88, 91}; // C7, E7, G7
+    TestUtil::assertVectorEquals(expected, c.toMidiNoteNumbers(), "C Major octave 7");
+}
+
+// ====================
+// Chord: toString() テスト
+// ====================
+
+void test_chord_toString_CMajor(void) {
+    Chord c(Chord::C, Chord::Major);
+    TEST_ASSERT_EQUAL_STRING("C", c.toString().c_str());
+}
+
+void test_chord_toString_CMinor(void) {
+    Chord c(Chord::C, Chord::Minor);
+    TEST_ASSERT_EQUAL_STRING("Cm", c.toString().c_str());
+}
+
+void test_chord_toString_CMinor7(void) {
+    Chord c(Chord::C, Chord::Minor | Chord::Seventh);
+    TEST_ASSERT_EQUAL_STRING("Cm7", c.toString().c_str());
+}
+
+void test_chord_toString_CMajor7(void) {
+    Chord c(Chord::C, Chord::MajorSeventh);
+    TEST_ASSERT_EQUAL_STRING("CM7", c.toString().c_str());
+}
+
+void test_chord_toString_C7(void) {
+    Chord c(Chord::C, Chord::Seventh);
+    TEST_ASSERT_EQUAL_STRING("C7", c.toString().c_str());
+}
+
+void test_chord_toString_Csus4(void) {
+    Chord c(Chord::C, Chord::Sus4);
+    TEST_ASSERT_EQUAL_STRING("Csus4", c.toString().c_str());
+}
+
+void test_chord_toString_Caug(void) {
+    Chord c(Chord::C, Chord::Aug);
+    TEST_ASSERT_EQUAL_STRING("Caug", c.toString().c_str());
+}
+
+void test_chord_toString_Cdim(void) {
+    Chord c(Chord::C, Chord::Dimish);
+    TEST_ASSERT_EQUAL_STRING("Cdim", c.toString().c_str());
+}
+
+void test_chord_toString_slashChord(void) {
+    Chord c(Chord::C, Chord::Major);
+    c.setBass(Chord::G);
+    TEST_ASSERT_EQUAL_STRING("C/G", c.toString().c_str());
+}
+
+void test_chord_toString_DMajor(void) {
+    Chord c(Chord::D, Chord::Major);
+    TEST_ASSERT_EQUAL_STRING("D", c.toString().c_str());
+}
+
+// ====================
+// Scale: コンストラクタテスト
+// ====================
+
+void test_scale_constructor_default(void) {
+    Scale s;
+    TEST_ASSERT_EQUAL(0, s.key);
+    TEST_ASSERT_NOT_NULL(s.currentScale);
+}
+
+void test_scale_constructor_withKey(void) {
+    Scale s(5); // F Major
+    TEST_ASSERT_EQUAL(5, s.key);
+    TEST_ASSERT_NOT_NULL(s.currentScale);
+}
+
+// ====================
+// Scale: toString() テスト
+// ====================
+
+void test_scale_toString_CMajor(void) {
+    Scale s(0); // C Major
+    TEST_ASSERT_EQUAL_STRING("C Major", s.toString().c_str());
+}
+
+void test_scale_toString_DMajor(void) {
+    Scale s(2); // D Major
+    TEST_ASSERT_EQUAL_STRING("D Major", s.toString().c_str());
+}
+
+void test_scale_toString_CMinor(void) {
+    Scale s(0); // C
+    s.currentScale = s.getAvailableScales()[1].get(); // Minor
+    TEST_ASSERT_EQUAL_STRING("C Minor", s.toString().c_str());
+}
+
+// ====================
+// Scale: getAvailableScales() テスト
+// ====================
+
+void test_scale_getAvailableScales(void) {
+    auto scales = Scale::getAvailableScales();
+    TEST_ASSERT_EQUAL(2, scales.size());
+    TEST_ASSERT_EQUAL_STRING("Major", scales[0]->name().c_str());
+    TEST_ASSERT_EQUAL_STRING("Minor", scales[1]->name().c_str());
+}
+
+// ====================
+// Scale: getScaleIndex() テスト
+// ====================
+
+void test_scale_getScaleIndex_major(void) {
+    Scale s(0);
+    s.currentScale = s.getAvailableScales()[0].get(); // Major
+    TEST_ASSERT_EQUAL(0, s.getScaleIndex());
+}
+
+void test_scale_getScaleIndex_minor(void) {
+    Scale s(0);
+    s.currentScale = s.getAvailableScales()[1].get(); // Minor
+    TEST_ASSERT_EQUAL(1, s.getScaleIndex());
+}
+
+// ====================
+// Scale: getScaleFromName() テスト
+// ====================
+
+void test_scale_getScaleFromName_major(void) {
+    Scale s;
+    ScaleBase* scale = s.getScaleFromName("Major");
+    TEST_ASSERT_NOT_NULL(scale);
+    TEST_ASSERT_EQUAL_STRING("Major", scale->name().c_str());
+}
+
+void test_scale_getScaleFromName_minor(void) {
+    Scale s;
+    ScaleBase* scale = s.getScaleFromName("Minor");
+    TEST_ASSERT_NOT_NULL(scale);
+    TEST_ASSERT_EQUAL_STRING("Minor", scale->name().c_str());
+}
+
+// ====================
+// MajorScale: getDiatonic() テスト
+// ====================
+
+void test_majorScale_getDiatonic_I(void) {
+    Scale s(0); // C Major
+    s.currentScale = s.getAvailableScales()[0].get();
+    Chord c = s.getDiatonic(0, false); // I (C Major)
+    TEST_ASSERT_EQUAL(Chord::C, c.root);
+    TEST_ASSERT_EQUAL(0, c.option); // Major
+}
+
+void test_majorScale_getDiatonic_ii(void) {
+    Scale s(0); // C Major
+    s.currentScale = s.getAvailableScales()[0].get();
+    Chord c = s.getDiatonic(1, false); // ii (D minor)
+    TEST_ASSERT_EQUAL(Chord::D, c.root);
+    TEST_ASSERT_EQUAL(Chord::Minor, c.option);
+}
+
+void test_majorScale_getDiatonic_iii(void) {
+    Scale s(0); // C Major
+    s.currentScale = s.getAvailableScales()[0].get();
+    Chord c = s.getDiatonic(2, false); // iii (E minor)
+    TEST_ASSERT_EQUAL(Chord::E, c.root);
+    TEST_ASSERT_EQUAL(Chord::Minor, c.option);
+}
+
+void test_majorScale_getDiatonic_IV(void) {
+    Scale s(0); // C Major
+    s.currentScale = s.getAvailableScales()[0].get();
+    Chord c = s.getDiatonic(3, false); // IV (F Major)
+    TEST_ASSERT_EQUAL(Chord::F, c.root);
+    TEST_ASSERT_EQUAL(0, c.option); // Major
+}
+
+void test_majorScale_getDiatonic_V(void) {
+    Scale s(0); // C Major
+    s.currentScale = s.getAvailableScales()[0].get();
+    Chord c = s.getDiatonic(4, false); // V (G Major)
+    TEST_ASSERT_EQUAL(Chord::G, c.root);
+    TEST_ASSERT_EQUAL(0, c.option); // Major
+}
+
+void test_majorScale_getDiatonic_vi(void) {
+    Scale s(0); // C Major
+    s.currentScale = s.getAvailableScales()[0].get();
+    Chord c = s.getDiatonic(5, false); // vi (A minor)
+    TEST_ASSERT_EQUAL(Chord::A, c.root);
+    TEST_ASSERT_EQUAL(Chord::Minor, c.option);
+}
+
+void test_majorScale_getDiatonic_vii(void) {
+    Scale s(0); // C Major
+    s.currentScale = s.getAvailableScales()[0].get();
+    Chord c = s.getDiatonic(6, false); // vii° (B dim)
+    TEST_ASSERT_EQUAL(Chord::B, c.root);
+    TEST_ASSERT_EQUAL(Chord::Minor | Chord::FifthFlat, c.option);
+}
+
+// ====================
+// MajorScale: getDiatonic() with Seventh テスト
+// ====================
+
+void test_majorScale_getDiatonic_IM7(void) {
+    Scale s(0); // C Major
+    s.currentScale = s.getAvailableScales()[0].get();
+    Chord c = s.getDiatonic(0, true); // IM7 (CM7)
+    TEST_ASSERT_EQUAL(Chord::C, c.root);
+    TEST_ASSERT_EQUAL(Chord::MajorSeventh, c.option);
+}
+
+void test_majorScale_getDiatonic_iim7(void) {
+    Scale s(0); // C Major
+    s.currentScale = s.getAvailableScales()[0].get();
+    Chord c = s.getDiatonic(1, true); // iim7 (Dm7)
+    TEST_ASSERT_EQUAL(Chord::D, c.root);
+    TEST_ASSERT_EQUAL(Chord::Minor | Chord::Seventh, c.option);
+}
+
+void test_majorScale_getDiatonic_V7(void) {
+    Scale s(0); // C Major
+    s.currentScale = s.getAvailableScales()[0].get();
+    Chord c = s.getDiatonic(4, true); // V7 (G7)
+    TEST_ASSERT_EQUAL(Chord::G, c.root);
+    TEST_ASSERT_EQUAL(Chord::Seventh, c.option);
+}
+
+void test_majorScale_getDiatonic_viim7b5(void) {
+    Scale s(0); // C Major
+    s.currentScale = s.getAvailableScales()[0].get();
+    Chord c = s.getDiatonic(6, true); // viim7b5 (Bm7b5)
+    TEST_ASSERT_EQUAL(Chord::B, c.root);
+    TEST_ASSERT_EQUAL(Chord::Minor | Chord::Seventh | Chord::FifthFlat, c.option);
+}
+
+// ====================
+// MinorScale: getDiatonic() テスト
+// ====================
+
+void test_minorScale_getDiatonic_i(void) {
+    Scale s(0); // C Minor
+    s.currentScale = s.getAvailableScales()[1].get(); // Minor
+    Chord c = s.getDiatonic(0, false); // i (C minor)
+    TEST_ASSERT_EQUAL(Chord::C, c.root);
+    TEST_ASSERT_EQUAL(Chord::Minor, c.option);
+}
+
+void test_minorScale_getDiatonic_ii(void) {
+    Scale s(0); // C Minor
+    s.currentScale = s.getAvailableScales()[1].get();
+    Chord c = s.getDiatonic(1, false); // ii° (D dim)
+    TEST_ASSERT_EQUAL(Chord::D, c.root);
+    TEST_ASSERT_EQUAL(Chord::Dimish, c.option);
+}
+
+void test_minorScale_getDiatonic_III(void) {
+    Scale s(0); // C Minor
+    s.currentScale = s.getAvailableScales()[1].get();
+    Chord c = s.getDiatonic(2, false); // III (Eb Major)
+    TEST_ASSERT_EQUAL(Chord::DSharp, c.root); // Eb = DSharp
+    TEST_ASSERT_EQUAL(0, c.option); // Major
+}
+
+void test_minorScale_getDiatonic_iv(void) {
+    Scale s(0); // C Minor
+    s.currentScale = s.getAvailableScales()[1].get();
+    Chord c = s.getDiatonic(3, false); // iv (F minor)
+    TEST_ASSERT_EQUAL(Chord::F, c.root);
+    TEST_ASSERT_EQUAL(Chord::Minor, c.option);
+}
+
+void test_minorScale_getDiatonic_v(void) {
+    Scale s(0); // C Minor
+    s.currentScale = s.getAvailableScales()[1].get();
+    Chord c = s.getDiatonic(4, false); // v (G minor)
+    TEST_ASSERT_EQUAL(Chord::G, c.root);
+    TEST_ASSERT_EQUAL(Chord::Minor, c.option);
+}
+
+void test_minorScale_getDiatonic_VI(void) {
+    Scale s(0); // C Minor
+    s.currentScale = s.getAvailableScales()[1].get();
+    Chord c = s.getDiatonic(5, false); // VI (Ab Major)
+    TEST_ASSERT_EQUAL(Chord::GSharp, c.root); // Ab = GSharp
+    TEST_ASSERT_EQUAL(0, c.option); // Major
+}
+
+void test_minorScale_getDiatonic_VII(void) {
+    Scale s(0); // C Minor
+    s.currentScale = s.getAvailableScales()[1].get();
+    Chord c = s.getDiatonic(6, false); // VII (Bb Major)
+    TEST_ASSERT_EQUAL(Chord::ASharp, c.root); // Bb = ASharp
+    TEST_ASSERT_EQUAL(0, c.option); // Major
+}
+
+// ====================
+// MinorScale: getDiatonic() with Seventh テスト
+// ====================
+
+void test_minorScale_getDiatonic_im7(void) {
+    Scale s(0); // C Minor
+    s.currentScale = s.getAvailableScales()[1].get();
+    Chord c = s.getDiatonic(0, true); // im7 (Cm7)
+    TEST_ASSERT_EQUAL(Chord::C, c.root);
+    TEST_ASSERT_EQUAL(Chord::Minor | Chord::Seventh, c.option);
+}
+
+void test_minorScale_getDiatonic_iim7b5(void) {
+    Scale s(0); // C Minor
+    s.currentScale = s.getAvailableScales()[1].get();
+    Chord c = s.getDiatonic(1, true); // iim7b5 (Dm7b5)
+    TEST_ASSERT_EQUAL(Chord::D, c.root);
+    TEST_ASSERT_EQUAL(Chord::Minor | Chord::Seventh | Chord::FifthFlat, c.option);
+}
+
+void test_minorScale_getDiatonic_IIIM7(void) {
+    Scale s(0); // C Minor
+    s.currentScale = s.getAvailableScales()[1].get();
+    Chord c = s.getDiatonic(2, true); // IIIM7 (EbM7)
+    TEST_ASSERT_EQUAL(Chord::DSharp, c.root); // Eb = DSharp
+    TEST_ASSERT_EQUAL(Chord::MajorSeventh, c.option);
+}
+
+void test_minorScale_getDiatonic_VII7(void) {
+    Scale s(0); // C Minor
+    s.currentScale = s.getAvailableScales()[1].get();
+    Chord c = s.getDiatonic(6, true); // VII7 (Bb7)
+    TEST_ASSERT_EQUAL(Chord::ASharp, c.root); // Bb = ASharp
+    TEST_ASSERT_EQUAL(Chord::Seventh, c.option);
+}
+
+// ====================
+// Scale: 異なるキーでのテスト
+// ====================
+
+void test_scale_getDiatonic_DMajor(void) {
+    Scale s(2); // D Major
+    s.currentScale = s.getAvailableScales()[0].get();
+    Chord c = s.getDiatonic(0, false); // I (D Major)
+    TEST_ASSERT_EQUAL(Chord::D, c.root);
+    TEST_ASSERT_EQUAL(0, c.option);
+}
+
+void test_scale_getDiatonic_DMajor_V(void) {
+    Scale s(2); // D Major
+    s.currentScale = s.getAvailableScales()[0].get();
+    Chord c = s.getDiatonic(4, false); // V (A Major)
+    TEST_ASSERT_EQUAL(Chord::A, c.root);
+    TEST_ASSERT_EQUAL(0, c.option);
+}
+
+void test_scale_getDiatonic_AMinor(void) {
+    Scale s(9); // A Minor
+    s.currentScale = s.getAvailableScales()[1].get();
+    Chord c = s.getDiatonic(0, false); // i (A minor)
+    TEST_ASSERT_EQUAL(Chord::A, c.root);
+    TEST_ASSERT_EQUAL(Chord::Minor, c.option);
+}
+
+// ====================
+// MusicalTime: time_in_bar() テスト
+// ====================
+
+void test_musicalTime_time_in_bar_zero(void) {
+    // 時間0は小節内位置0
+    TEST_ASSERT_EQUAL(0, time_in_bar(0));
+}
+
+void test_musicalTime_time_in_bar_quarterNote(void) {
+    // 4分音符1つ = 480 ticks
+    TEST_ASSERT_EQUAL(480, time_in_bar(480));
+}
+
+void test_musicalTime_time_in_bar_halfBar(void) {
+    // 半小節 = 960 ticks (4/4拍子で2拍)
+    TEST_ASSERT_EQUAL(960, time_in_bar(960));
+}
+
+void test_musicalTime_time_in_bar_oneBar(void) {
+    // 1小節 = 1920 ticks (4/4拍子で4拍)
+    // 1小節ちょうどは次の小節の開始なので位置0
+    TEST_ASSERT_EQUAL(0, time_in_bar(1920));
+}
+
+void test_musicalTime_time_in_bar_oneBarPlus(void) {
+    // 1小節 + 480 ticks
+    TEST_ASSERT_EQUAL(480, time_in_bar(1920 + 480));
+}
+
+void test_musicalTime_time_in_bar_multipleBars(void) {
+    // 5小節 + 240 ticks
+    TEST_ASSERT_EQUAL(240, time_in_bar(5 * 1920 + 240));
+}
+
+void test_musicalTime_time_in_bar_negative(void) {
+    // 負の時間の場合 (C++のモジュロ演算は負数で負の結果を返す可能性がある)
+    // -480は最後の小節の1440の位置になるべき
+    musical_time_t result = time_in_bar(-480);
+    // C++のモジュロは実装依存だが、一般的には負の結果を返す
+    // この実装では % 1920 の結果をそのまま返すので、-480 % 1920 = -480
+    TEST_ASSERT_EQUAL(-480, result);
+}
+
+// ====================
+// テスト実行の共通化
+// ====================
+
+void runAllTests() {
+    // ===== Chord テスト =====
+
+    // コンストラクタテスト
+    RUN_TEST(test_chord_constructor_default);
+    RUN_TEST(test_chord_constructor_withParams);
+    RUN_TEST(test_chord_copyConstructor);
+
+    // toMidiNoteNumbers() テスト
+    RUN_TEST(test_chord_toMidiNoteNumbers_CMajor);
+    RUN_TEST(test_chord_toMidiNoteNumbers_CMinor);
+    RUN_TEST(test_chord_toMidiNoteNumbers_CMinor7);
+    RUN_TEST(test_chord_toMidiNoteNumbers_CMajor7);
+    RUN_TEST(test_chord_toMidiNoteNumbers_C7);
+    RUN_TEST(test_chord_toMidiNoteNumbers_Csus4);
+    RUN_TEST(test_chord_toMidiNoteNumbers_Csus2);
+    RUN_TEST(test_chord_toMidiNoteNumbers_Caug);
+    RUN_TEST(test_chord_toMidiNoteNumbers_Cdim);
+    RUN_TEST(test_chord_toMidiNoteNumbers_DMajor);
+    RUN_TEST(test_chord_toMidiNoteNumbers_GMajor);
+
+    // 転回形テスト
+    RUN_TEST(test_chord_inversion_first);
+    RUN_TEST(test_chord_inversion_second);
+    RUN_TEST(test_chord_inversion_Cm7_first);
+
+    // オクターブテスト
+    RUN_TEST(test_chord_octave_low);
+    RUN_TEST(test_chord_octave_high);
+
+    // toString() テスト
+    RUN_TEST(test_chord_toString_CMajor);
+    RUN_TEST(test_chord_toString_CMinor);
+    RUN_TEST(test_chord_toString_CMinor7);
+    RUN_TEST(test_chord_toString_CMajor7);
+    RUN_TEST(test_chord_toString_C7);
+    RUN_TEST(test_chord_toString_Csus4);
+    RUN_TEST(test_chord_toString_Caug);
+    RUN_TEST(test_chord_toString_Cdim);
+    RUN_TEST(test_chord_toString_slashChord);
+    RUN_TEST(test_chord_toString_DMajor);
+
+    // ===== Scale テスト =====
+
+    // コンストラクタテスト
+    RUN_TEST(test_scale_constructor_default);
+    RUN_TEST(test_scale_constructor_withKey);
+
+    // toString() テスト
+    RUN_TEST(test_scale_toString_CMajor);
+    RUN_TEST(test_scale_toString_DMajor);
+    RUN_TEST(test_scale_toString_CMinor);
+
+    // getAvailableScales() テスト
+    RUN_TEST(test_scale_getAvailableScales);
+
+    // getScaleIndex() テスト
+    RUN_TEST(test_scale_getScaleIndex_major);
+    RUN_TEST(test_scale_getScaleIndex_minor);
+
+    // getScaleFromName() テスト
+    RUN_TEST(test_scale_getScaleFromName_major);
+    RUN_TEST(test_scale_getScaleFromName_minor);
+
+    // MajorScale::getDiatonic() テスト
+    RUN_TEST(test_majorScale_getDiatonic_I);
+    RUN_TEST(test_majorScale_getDiatonic_ii);
+    RUN_TEST(test_majorScale_getDiatonic_iii);
+    RUN_TEST(test_majorScale_getDiatonic_IV);
+    RUN_TEST(test_majorScale_getDiatonic_V);
+    RUN_TEST(test_majorScale_getDiatonic_vi);
+    RUN_TEST(test_majorScale_getDiatonic_vii);
+
+    // MajorScale::getDiatonic() with Seventh テスト
+    RUN_TEST(test_majorScale_getDiatonic_IM7);
+    RUN_TEST(test_majorScale_getDiatonic_iim7);
+    RUN_TEST(test_majorScale_getDiatonic_V7);
+    RUN_TEST(test_majorScale_getDiatonic_viim7b5);
+
+    // MinorScale::getDiatonic() テスト
+    RUN_TEST(test_minorScale_getDiatonic_i);
+    RUN_TEST(test_minorScale_getDiatonic_ii);
+    RUN_TEST(test_minorScale_getDiatonic_III);
+    RUN_TEST(test_minorScale_getDiatonic_iv);
+    RUN_TEST(test_minorScale_getDiatonic_v);
+    RUN_TEST(test_minorScale_getDiatonic_VI);
+    RUN_TEST(test_minorScale_getDiatonic_VII);
+
+    // MinorScale::getDiatonic() with Seventh テスト
+    RUN_TEST(test_minorScale_getDiatonic_im7);
+    RUN_TEST(test_minorScale_getDiatonic_iim7b5);
+    RUN_TEST(test_minorScale_getDiatonic_IIIM7);
+    RUN_TEST(test_minorScale_getDiatonic_VII7);
+
+    // 異なるキーでのテスト
+    RUN_TEST(test_scale_getDiatonic_DMajor);
+    RUN_TEST(test_scale_getDiatonic_DMajor_V);
+    RUN_TEST(test_scale_getDiatonic_AMinor);
+
+    // ===== MusicalTime テスト =====
+
+    // time_in_bar() テスト
+    RUN_TEST(test_musicalTime_time_in_bar_zero);
+    RUN_TEST(test_musicalTime_time_in_bar_quarterNote);
+    RUN_TEST(test_musicalTime_time_in_bar_halfBar);
+    RUN_TEST(test_musicalTime_time_in_bar_oneBar);
+    RUN_TEST(test_musicalTime_time_in_bar_oneBarPlus);
+    RUN_TEST(test_musicalTime_time_in_bar_multipleBars);
+    RUN_TEST(test_musicalTime_time_in_bar_negative);
+}
+
+// ====================
+// メインテスト実行
+// ====================
+
+#ifdef NATIVE_TEST
+int main(int argc, char **argv) {
+    UNITY_BEGIN();
+    runAllTests();
+    return UNITY_END();
+}
+#else
+void setup() {
+    delay(2000);
+    UNITY_BEGIN();
+    runAllTests();
+    UNITY_END();
+}
+
+void loop() {}
+#endif

--- a/test/test_music.cpp
+++ b/test/test_music.cpp
@@ -88,7 +88,7 @@ void test_chord_toMidiNoteNumbers_Csus4(void) {
 
 void test_chord_toMidiNoteNumbers_Csus2(void) {
     Chord c(Chord::C, Chord::Sus2, 0, 4);
-    std::vector<uint8_t> expected = {48, 52, 55}; // C3, E3(Major third), G3
+    std::vector<uint8_t> expected = {48, 50, 55}; // C3, D3, G3
     TestUtil::assertVectorEquals(expected, c.toMidiNoteNumbers(), "Csus2");
 }
 
@@ -100,7 +100,7 @@ void test_chord_toMidiNoteNumbers_Caug(void) {
 
 void test_chord_toMidiNoteNumbers_Cdim(void) {
     Chord c(Chord::C, Chord::Dimish, 0, 4);
-    std::vector<uint8_t> expected = {48, 52, 55}; // C3, E3(Major third), G3(Perfect fifth) - 実装ではDimishはMajor triadと同じ構成音
+    std::vector<uint8_t> expected = {48, 51, 54}; // C3, Eb3, Gb3
     TestUtil::assertVectorEquals(expected, c.toMidiNoteNumbers(), "Cdim");
 }
 
@@ -546,12 +546,9 @@ void test_musicalTime_time_in_bar_multipleBars(void) {
 }
 
 void test_musicalTime_time_in_bar_negative(void) {
-    // 負の時間の場合 (C++のモジュロ演算は負数で負の結果を返す可能性がある)
-    // -480は最後の小節の1440の位置になるべき
+    // time_in_barに負の値を渡した場合でも、0から1920までの値を返すのが望ましい
     musical_time_t result = time_in_bar(-480);
-    // C++のモジュロは実装依存だが、一般的には負の結果を返す
-    // この実装では % 1920 の結果をそのまま返すので、-480 % 1920 = -480
-    TEST_ASSERT_EQUAL(-480, result);
+    TEST_ASSERT_EQUAL(1440, result);
 }
 
 // ====================
@@ -673,13 +670,7 @@ void runAllTests() {
 // メインテスト実行
 // ====================
 
-#ifdef NATIVE_TEST
-int main(int argc, char **argv) {
-    UNITY_BEGIN();
-    runAllTests();
-    return UNITY_END();
-}
-#else
+#ifdef ARDUINO
 void setup() {
     delay(2000);
     UNITY_BEGIN();
@@ -688,4 +679,10 @@ void setup() {
 }
 
 void loop() {}
+#else
+int main(int argc, char **argv) {
+    UNITY_BEGIN();
+    runAllTests();
+    return UNITY_END();
+}
 #endif


### PR DESCRIPTION
下記のクラスに関するテストを追加

* Chord
* Scale
* MusicalTime

実機でのテストを行うためには、ソースコードの一部をlibフォルダ以下に移動させる必要があるようです。
したがって、現状ではネイティブビルドでのテストのみとします。
参考: https://fum1h1ro.github.io/2021/01/26/m5paper-test/