### PR TITLE
新しいキーパッドプロトコルに対応

### DIFF
--- a/src/I2CHandler.cpp
+++ b/src/I2CHandler.cpp
@@ -134,6 +134,10 @@ void I2CHandler::i2cLoop() {
 
         if (M5.BtnPWR.wasHold()) {
             // 電源ボタンが長押しされた場合、シャットダウンを要求
+            // 電源OFF前にキーパッドの全LEDを消灯
+            // (USB給電時は5V系のLEDが電源OFF後も点灯し続けるため)
+            Keypad.turnOffAllLeds();
+            vTaskDelay(pdMS_TO_TICKS(40));
             M5.Power.powerOff();
         }
 

--- a/src/Keypad.cpp
+++ b/src/Keypad.cpp
@@ -237,6 +237,15 @@ void CapsuleChordKeypad::markLedNeedsUpdate() {
     _needsLedUpdate = true;
 }
 
+void CapsuleChordKeypad::turnOffAllLeds() {
+    if (_protocol != KeypadProtocol::V3) return;
+    uint8_t data[2] = {REG_GLOBAL_BRIGHTNESS, 0x00};
+    if (M5.Ex_I2C.start(KEYPAD_I2C_ADDR, false, 400000)) {
+        M5.Ex_I2C.write(data, 2);
+        M5.Ex_I2C.stop();
+    }
+}
+
 void CapsuleChordKeypad::updateLeds() {
     if (_ledLayers.empty()) return;
     

--- a/src/Keypad.cpp
+++ b/src/Keypad.cpp
@@ -114,11 +114,7 @@ uint8_t CapsuleChordKeypad::readKeyEventV3() {
 }
 
 void CapsuleChordKeypad::update() {
-    uint8_t val = (_protocol == KeypadProtocol::V3)
-        ? readKeyEventV3()
-        : readKeyEventLegacy();
-
-    if (val != 0) {
+    auto dispatch = [this](uint8_t val) {
         KeyEvent event(static_cast<char>(val));
 
         int keyCode = event.getKeyCode();
@@ -129,6 +125,20 @@ void CapsuleChordKeypad::update() {
         else keys[keyCode].release();
 
         processKeyEvent(event);
+    };
+
+    if (_protocol == KeypadProtocol::V3) {
+        // V3はFIFOなのでポーリング間隔中に積まれた分をまとめて取り出す。
+        // 想定外の事態でループが抜けない場合に備え、1回の更新での処理数に上限を設ける。
+        constexpr int MAX_EVENTS_PER_UPDATE = 32;
+        for (int i = 0; i < MAX_EVENTS_PER_UPDATE; ++i) {
+            uint8_t val = readKeyEventV3();
+            if (val == 0) break;
+            dispatch(val);
+        }
+    } else {
+        uint8_t val = readKeyEventLegacy();
+        if (val != 0) dispatch(val);
     }
 
     // Update LEDs if needed

--- a/src/Keypad.cpp
+++ b/src/Keypad.cpp
@@ -187,6 +187,11 @@ void CapsuleChordKeypad::writeLedBrightnessLegacy(uint8_t keyCode, uint8_t brigh
 
 void CapsuleChordKeypad::writeLedBrightnessV3(uint8_t keyCode, uint8_t brightness) {
     // REG_LED_BRIGHT_BASE (0x70) + sparse keycode, 1B data.
+    // keyCode が REG_GLOBAL_BRIGHTNESS (0xC8) 以降の領域に被ると別レジスタを誤書きするため、ここで弾く。
+    if (keyCode >= (REG_GLOBAL_BRIGHTNESS - REG_LED_BRIGHT_BASE)) {
+        ESP_LOGW(LOG_TAG, "keyCode 0x%02X out of V3 LED register range, skipped", keyCode);
+        return;
+    }
     uint8_t data[2] = {static_cast<uint8_t>(REG_LED_BRIGHT_BASE + keyCode), brightness};
     if (M5.Ex_I2C.start(KEYPAD_I2C_ADDR, false, 400000)) {
         M5.Ex_I2C.write(data, 2);

--- a/src/Keypad.cpp
+++ b/src/Keypad.cpp
@@ -13,16 +13,31 @@ void CapsuleChordKeypad::begin() {
     if (_initialized) return;  // 多重初期化を防止
 
     M5.Ex_I2C.begin(EXT_I2C_PORT, PORTA_SDA, PORTA_SCL);
-    // キーパッド側のイベントキューをクリア
-    while (true) {
+
+    // Step 1: 旧FW互換のbareリードでイベントキューをドレインする。
+    // 新FWでpointer未設定のbareリードが非ゼロを返し続ける場合に備え、
+    // 反復回数に上限を設ける。
+    for (int i = 0; i < 32; i++) {
         uint8_t data = 0;
-        if (!M5.Ex_I2C.start(KEYPAD_I2C_ADDR, true, 400000)) break;  // read mode
+        if (!M5.Ex_I2C.start(KEYPAD_I2C_ADDR, true, 400000)) break;
         if (!M5.Ex_I2C.read(&data, 1)) {
             M5.Ex_I2C.stop();
             break;
         }
         M5.Ex_I2C.stop();
         if (data == 0) break;
+    }
+
+    // Step 2: キューが空になったうえでFWバージョンを問い合わせ、
+    // プロトコル種別を判定する。
+    _protocol = detectProtocol();
+
+    // Step 3: 新FWの場合はREG_KEY_EVENT経由でもう一度ドレインしておく
+    // (step1のbareリードが新FWで効かない可能性があるため)。
+    if (_protocol == KeypadProtocol::V3) {
+        for (int i = 0; i < 32; i++) {
+            if (readKeyEventV3() == 0) break;
+        }
     }
 
     // LEDベースレイヤーを登録
@@ -33,43 +48,87 @@ void CapsuleChordKeypad::begin() {
     _initialized = true;
 }
 
-void CapsuleChordKeypad::update() {
-    // Send command to get key event
+KeypadProtocol CapsuleChordKeypad::detectProtocol() {
+    uint8_t regAddr = REG_FW_VERSION;
+    uint8_t version[2] = {0, 0};
+
+    if (!M5.Ex_I2C.start(KEYPAD_I2C_ADDR, false, 400000)) {
+        ESP_LOGW(LOG_TAG, "Version probe write-start failed, falling back to legacy");
+        return KeypadProtocol::Legacy;
+    }
+    bool writeOk = M5.Ex_I2C.write(&regAddr, 1);
+    M5.Ex_I2C.stop();
+    if (!writeOk) {
+        ESP_LOGW(LOG_TAG, "Version probe write failed, falling back to legacy");
+        return KeypadProtocol::Legacy;
+    }
+
+    if (!M5.Ex_I2C.start(KEYPAD_I2C_ADDR, true, 400000)) {
+        ESP_LOGW(LOG_TAG, "Version probe read-start failed, falling back to legacy");
+        return KeypadProtocol::Legacy;
+    }
+    bool readOk = M5.Ex_I2C.read(version, 2);
+    M5.Ex_I2C.stop();
+    if (!readOk) {
+        ESP_LOGW(LOG_TAG, "Version probe read failed, falling back to legacy");
+        return KeypadProtocol::Legacy;
+    }
+
+    if (version[0] >= 3) {
+        ESP_LOGI(LOG_TAG, "Keypad firmware v%u.%u detected (new protocol)",
+                 version[0], version[1]);
+        return KeypadProtocol::V3;
+    }
+
+    ESP_LOGI(LOG_TAG, "Legacy keypad firmware detected (version bytes: 0x%02X 0x%02X)",
+             version[0], version[1]);
+    return KeypadProtocol::Legacy;
+}
+
+uint8_t CapsuleChordKeypad::readKeyEventLegacy() {
     uint8_t cmd = CMD_GET_KEY_EVENT;
-    if (M5.Ex_I2C.start(KEYPAD_I2C_ADDR, false, 400000)) {  // write mode
+    uint8_t val = 0;
+    if (M5.Ex_I2C.start(KEYPAD_I2C_ADDR, false, 400000)) {
         M5.Ex_I2C.write(&cmd, 1);
         M5.Ex_I2C.stop();
     }
-
-    // Read key event data
-    uint8_t val = 0;
-    if (M5.Ex_I2C.start(KEYPAD_I2C_ADDR, true, 400000)) {  // read mode
-        if (M5.Ex_I2C.read(&val, 1)) {
-            if (val != 0) {
-                // KeyEventオブジェクトを作成
-                KeyEvent event(static_cast<char>(val));
-
-                // Update keys
-                int keyCode = event.getKeyCode();
-                if (keys.find(keyCode) != keys.end())
-                {
-                    if(event.isPressed()) keys[keyCode].press();
-                    else keys[keyCode].release();
-                }
-                else
-                {
-                    keys[keyCode] = Key();
-                    if(event.isPressed()) keys[keyCode].press();
-                    else keys[keyCode].release();
-                }
-
-                // Process the event through listener stack
-                if (processKeyEvent(event)) {
-                    // Event was consumed by a listener
-                }
-            }
-        }
+    if (M5.Ex_I2C.start(KEYPAD_I2C_ADDR, true, 400000)) {
+        M5.Ex_I2C.read(&val, 1);
         M5.Ex_I2C.stop();
+    }
+    return val;
+}
+
+uint8_t CapsuleChordKeypad::readKeyEventV3() {
+    uint8_t regAddr = REG_KEY_EVENT;
+    uint8_t val = 0;
+    if (M5.Ex_I2C.start(KEYPAD_I2C_ADDR, false, 400000)) {
+        M5.Ex_I2C.write(&regAddr, 1);
+        M5.Ex_I2C.stop();
+    }
+    if (M5.Ex_I2C.start(KEYPAD_I2C_ADDR, true, 400000)) {
+        M5.Ex_I2C.read(&val, 1);
+        M5.Ex_I2C.stop();
+    }
+    return val;
+}
+
+void CapsuleChordKeypad::update() {
+    uint8_t val = (_protocol == KeypadProtocol::V3)
+        ? readKeyEventV3()
+        : readKeyEventLegacy();
+
+    if (val != 0) {
+        KeyEvent event(static_cast<char>(val));
+
+        int keyCode = event.getKeyCode();
+        if (keys.find(keyCode) == keys.end()) {
+            keys[keyCode] = Key();
+        }
+        if (event.isPressed()) keys[keyCode].press();
+        else keys[keyCode].release();
+
+        processKeyEvent(event);
     }
 
     // Update LEDs if needed
@@ -111,10 +170,26 @@ void CapsuleChordKeypad::setLedBrightness(uint8_t keyCode, uint8_t brightness) {
         brightness = LED_OFF;
     }
 
-    // Send command through I2C using M5Unified
+    if (_protocol == KeypadProtocol::V3) {
+        writeLedBrightnessV3(keyCode, brightness);
+    } else {
+        writeLedBrightnessLegacy(keyCode, brightness);
+    }
+}
+
+void CapsuleChordKeypad::writeLedBrightnessLegacy(uint8_t keyCode, uint8_t brightness) {
     uint8_t data[3] = {CMD_SET_LED, keyCode, brightness};
-    if (M5.Ex_I2C.start(KEYPAD_I2C_ADDR, false, 400000)) {  // write mode
+    if (M5.Ex_I2C.start(KEYPAD_I2C_ADDR, false, 400000)) {
         M5.Ex_I2C.write(data, 3);
+        M5.Ex_I2C.stop();
+    }
+}
+
+void CapsuleChordKeypad::writeLedBrightnessV3(uint8_t keyCode, uint8_t brightness) {
+    // REG_LED_BRIGHT_BASE (0x70) + sparse keycode, 1B data.
+    uint8_t data[2] = {static_cast<uint8_t>(REG_LED_BRIGHT_BASE + keyCode), brightness};
+    if (M5.Ex_I2C.start(KEYPAD_I2C_ADDR, false, 400000)) {
+        M5.Ex_I2C.write(data, 2);
         M5.Ex_I2C.stop();
     }
 }

--- a/src/Keypad.h
+++ b/src/Keypad.h
@@ -18,6 +18,7 @@
 // Full map: src/protocol/registers.h on the keypad firmware
 #define REG_FW_VERSION       0x00  // RO 2B [major, minor]
 #define REG_LED_BRIGHT_BASE  0x70  // RW 1B per key (0x70 + kc)
+#define REG_GLOBAL_BRIGHTNESS 0xC8 // WO 1B (write 0x00 to turn all LEDs off)
 #define REG_KEY_EVENT        0xD0  // RO 1B FIFO pop (state<<7 | kc, 0x00 if empty)
 
 // Keypad firmware protocol variant (detected at begin()).
@@ -256,6 +257,12 @@ public:
     void removeLedLayer(std::shared_ptr<LedLayer> layer);
 
     void markLedNeedsUpdate();
+
+    // Force-turn off all LEDs via REG_GLOBAL_BRIGHTNESS (V3 protocol only).
+    // 電源OFF直前に呼ぶ。USB給電時、本体3.3Vが切れた後も5V系のLEDは
+    // 給電が続くため、ハードウェア側で消灯させておく必要がある。
+    // Legacy FWではno-op。
+    void turnOffAllLeds();
     
     class Key {
         private:

--- a/src/Keypad.h
+++ b/src/Keypad.h
@@ -10,9 +10,22 @@
 
 #define KEYPAD_I2C_ADDR 0x09
 
-// I2C Commands
+// Legacy protocol I2C Commands (v2.x firmware)
 #define CMD_GET_KEY_EVENT 0x01
 #define CMD_SET_LED 0x02
+
+// New protocol registers (v3.0+ firmware, SMBus style)
+// Full map: src/protocol/registers.h on the keypad firmware
+#define REG_FW_VERSION       0x00  // RO 2B [major, minor]
+#define REG_LED_BRIGHT_BASE  0x70  // RW 1B per key (0x70 + kc)
+#define REG_KEY_EVENT        0xD0  // RO 1B FIFO pop (state<<7 | kc, 0x00 if empty)
+
+// Keypad firmware protocol variant (detected at begin()).
+// Legacy path will be removed once all deployed keypads ship with v3.0+.
+enum class KeypadProtocol : uint8_t {
+    Legacy = 0,
+    V3 = 3
+};
 
 // LED Brightness Levels
 #define LED_BRIGHT 0
@@ -209,10 +222,18 @@ private:
     // Get the current top LED layer (for debugging)
     std::shared_ptr<LedLayer> getTopLedLayer() const;
 
+    // Protocol detection + per-protocol I2C helpers
+    KeypadProtocol detectProtocol();
+    uint8_t readKeyEventLegacy();
+    uint8_t readKeyEventV3();
+    void writeLedBrightnessLegacy(uint8_t keyCode, uint8_t brightness);
+    void writeLedBrightnessV3(uint8_t keyCode, uint8_t brightness);
+
     // LED Layer Management
     std::vector<std::shared_ptr<LedLayer>> _ledLayers;
     bool _needsLedUpdate = true;
     bool _initialized = false;  // 初期化済みフラグ
+    KeypadProtocol _protocol = KeypadProtocol::Legacy;
 
 public:
     void begin();


### PR DESCRIPTION
[migration-guide.md](https://github.com/user-attachments/files/27081608/migration-guide.md) に従って、新しいキーパッドのプロトコルに移行した。

古いプロトコルへのフォールバック動作も実装した。