### PR TITLE
メインメニューから明るさを変更する機能を追加

### DIFF
--- a/src/Display/DisplayController.cpp
+++ b/src/Display/DisplayController.cpp
@@ -1,0 +1,28 @@
+#include "DisplayController.h"
+#include <M5Unified.h>
+
+DisplayController Display;
+
+void DisplayController::begin() {
+    applyBrightnessLevel(Settings.display.brightness.get());
+    brightnessToken = Settings.display.brightness.subscribe(
+        [](const uint8_t&, const uint8_t& newVal) {
+            applyBrightnessLevel(newVal);
+        });
+}
+
+void DisplayController::end() {
+    if (brightnessToken != 0) {
+        Settings.display.brightness.unsubscribe(brightnessToken);
+        brightnessToken = 0;
+    }
+}
+
+void DisplayController::applyBrightnessLevel(uint8_t level) {
+    switch (level) {
+        case 0: M5.Lcd.setBrightness(255); break;
+        case 1: M5.Lcd.setBrightness(127); break;
+        case 2: M5.Lcd.setBrightness(32);  break;
+        default: M5.Lcd.setBrightness(127); break;
+    }
+}

--- a/src/Display/DisplayController.h
+++ b/src/Display/DisplayController.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <stdint.h>
+#include "SettingsStore.h"
+
+class DisplayController {
+public:
+    void begin();
+    void end();
+
+private:
+    static void applyBrightnessLevel(uint8_t level);
+
+    SettingDescriptor<uint8_t>::SubscriptionToken brightnessToken = 0;
+};
+
+extern DisplayController Display;

--- a/src/Keypad.cpp
+++ b/src/Keypad.cpp
@@ -261,6 +261,32 @@ void CapsuleChordKeypad::turnOffAllLeds() {
     }
 }
 
+void CapsuleChordKeypad::setGlobalBrightness(uint8_t value) {
+    if (_protocol != KeypadProtocol::V3) return;
+    uint8_t data[2] = {REG_GLOBAL_BRIGHTNESS, value};
+    if (M5.Ex_I2C.start(KEYPAD_I2C_ADDR, false, 400000)) {
+        M5.Ex_I2C.write(data, 2);
+        M5.Ex_I2C.stop();
+    }
+}
+
+uint8_t CapsuleChordKeypad::brightnessLevelToValue(uint8_t level) {
+    switch (level) {
+        case 0: return 64;   // 明るい
+        case 1: return 32;   // 普通
+        case 2: return 16;   // 暗い
+        default: return 32;
+    }
+}
+
+void CapsuleChordKeypad::subscribeBrightnessSetting() {
+    setGlobalBrightness(brightnessLevelToValue(Settings.display.keypadBrightness.get()));
+    brightnessToken = Settings.display.keypadBrightness.subscribe(
+        [this](const uint8_t&, const uint8_t& newVal) {
+            setGlobalBrightness(brightnessLevelToValue(newVal));
+        });
+}
+
 void CapsuleChordKeypad::updateLeds() {
     if (_ledLayers.empty()) return;
     

--- a/src/Keypad.h
+++ b/src/Keypad.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <array>
 #include <string>
+#include "SettingsStore.h"
 
 #define KEYPAD_I2C_ADDR 0x09
 
@@ -236,6 +237,10 @@ private:
     bool _initialized = false;  // 初期化済みフラグ
     KeypadProtocol _protocol = KeypadProtocol::Legacy;
 
+    // 設定値 (0:Bright, 1:Normal, 2:Dark) を REG_GLOBAL_BRIGHTNESS の生値に変換
+    static uint8_t brightnessLevelToValue(uint8_t level);
+    SettingDescriptor<uint8_t>::SubscriptionToken brightnessToken = 0;
+
 public:
     void begin();
     void update();
@@ -263,6 +268,16 @@ public:
     // 給電が続くため、ハードウェア側で消灯させておく必要がある。
     // Legacy FWではno-op。
     void turnOffAllLeds();
+
+    // Set global LED brightness (V3 protocol only).
+    // value は 0-255 の PWM 生値。各キーの個別輝度に乗算的に作用する。
+    // Legacy FWではno-op。
+    void setGlobalBrightness(uint8_t value);
+
+    // Settings.display.keypadBrightness を購読して全体輝度を制御する。
+    // begin() とは分離し、Settings.loadAll() の後に呼ぶ必要がある
+    // （初期化順序: Keypad.begin() → Settings.loadAll() → ここ）。
+    void subscribeBrightnessSetting();
     
     class Key {
         private:

--- a/src/SettingsStore.cpp
+++ b/src/SettingsStore.cpp
@@ -167,14 +167,17 @@ void OutputSettings::deserializeItems(InputArchive& archive) {
 // DisplaySettings
 DisplaySettings::DisplaySettings(SettingsStore* store)
     : SettingsCategoryBase("/settings/display.json"),
-      brightness("brightness", 1, &isDirty, store) {}  // 1 = Normal
+      brightness("brightness", 1, &isDirty, store),                // 1 = Normal
+      keypadBrightness("keypadBrightness", 1, &isDirty, store) {}  // 1 = Normal
 
 void DisplaySettings::serializeItems(OutputArchive& archive) const {
     brightness.serialize(archive);
+    keypadBrightness.serialize(archive);
 }
 
 void DisplaySettings::deserializeItems(InputArchive& archive) {
     brightness.deserialize(archive);
+    keypadBrightness.deserialize(archive);
 }
 
 // SystemSettings

--- a/src/SettingsStore.h
+++ b/src/SettingsStore.h
@@ -177,7 +177,8 @@ protected:
 // 表示設定
 class DisplaySettings : public SettingsCategoryBase {
 public:
-    SettingDescriptor<uint8_t> brightness;  // 画面の明るさ (0:Bright, 1:Normal, 2:Dark)
+    SettingDescriptor<uint8_t> brightness;          // 画面の明るさ (0:Bright, 1:Normal, 2:Dark)
+    SettingDescriptor<uint8_t> keypadBrightness;    // キーパッドLEDの全体輝度 (0:Bright, 1:Normal, 2:Dark)
 
     DisplaySettings(SettingsStore* store);
 

--- a/src/Widget/MenuScreen.cpp
+++ b/src/Widget/MenuScreen.cpp
@@ -406,6 +406,18 @@ void MenuScreen::buildDisplayCategory() {
         [](int v) { Settings.display.brightness.set(static_cast<uint8_t>(v)); }
     ));
 
+    // キーパッドLEDの明るさ
+    category.items.push_back(std::make_unique<MenuItemSelection>(
+        "キー明るさ",
+        std::vector<MenuItemSelection::Option>{
+            {"明るい", 0},
+            {"普通", 1},
+            {"暗い", 2}
+        },
+        []() { return Settings.display.keypadBrightness.get(); },
+        [](int v) { Settings.display.keypadBrightness.set(static_cast<uint8_t>(v)); }
+    ));
+
     categories.push_back(std::move(category));
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,6 +51,7 @@ static inline int esp_digitalRead(gpio_num_t pin) {
 #include "I2CHandler.h"
 #include "LittleFSManager.h"
 #include "Output/UsbComposite.h"
+#include "Display/DisplayController.h"
 
 #define GPIO_NUM_BACK GPIO_NUM_7
 #define GPIO_NUM_HOME GPIO_NUM_5
@@ -135,12 +136,12 @@ void setup() {
   // Load settings from LittleFS (each category)
   Settings.loadAll();
 
-  // Set lcd brightness
-  switch(Settings.display.brightness.get()) {
-    case 0: M5.Lcd.setBrightness(255); break;
-    case 1: M5.Lcd.setBrightness(127); break;
-    case 2: M5.Lcd.setBrightness(32); break;
-  }
+  // 画面まわりの初期化（明るさ反映と設定変更購読）
+  Display.begin();
+
+  // キーパッドLED全体輝度の設定購読（Keypad.begin()はSettings.loadAll()前に
+  // 呼ばれているため、購読セットアップはここで行う必要がある）
+  Keypad.subscribeBrightnessSetting();
 
   // Keymap initialization
   currentKeyMap = KeyMap::getAvailableKeyMaps()[0].get();


### PR DESCRIPTION
画面の明るさとキーパッドLEDの明るさを変更できる

キーパッドについて、V2プロトコルではそもそもLED全体の明るさを設定する機能がないのでV3プロトコルのみ対応でOK