### PR TITLE
TempoController Tick配送を専用タスクに分離してTmr Svcのスタックオーバーフローを修正

### DIFF
--- a/src/Tempo.cpp
+++ b/src/Tempo.cpp
@@ -126,6 +126,9 @@ void TempoController::setTempo(tempo_t newTempo)
 
 void TempoController::begin()
 {
+    // 呼び出し元はシングルスレッド (setup() およびメインループ経由の play()) であることを前提とする。
+    // 複数スレッドから同時に呼ぶとキュー／タスクを二重生成する TOCTOU があるため、
+    // 並行呼び出しが必要になった場合はここをロックで保護すること。
     // 既に初期化済みなら何もしない (多重呼び出し・遅延初期化の両方に対応)
     if (tickQueue != nullptr && dispatchTask != nullptr) return;
 
@@ -171,6 +174,10 @@ void TempoController::dispatchLoop()
     for (;;)
     {
         if (xQueueReceive(tickQueue, &info, portMAX_DELAY) != pdTRUE) continue;
+
+        // デキュー後・配送前に stop() が走った場合、stop() の xQueueReset では
+        // 既に取り出したこの info は止められない。再生中でなければ配送しない。
+        if (!isPlaying) continue;
 
         std::list<TempoCallbacks *> listenersCopy;
         portENTER_CRITICAL(&mutex);

--- a/src/Tempo.cpp
+++ b/src/Tempo.cpp
@@ -124,9 +124,76 @@ void TempoController::setTempo(tempo_t newTempo)
     }
 }
 
+void TempoController::begin()
+{
+    // 既に初期化済みなら何もしない (多重呼び出し・遅延初期化の両方に対応)
+    if (tickQueue != nullptr && dispatchTask != nullptr) return;
+
+    if (tickQueue == nullptr)
+    {
+        // 1ms ごとに最大 MAX_FIRES(32) 個発火しうるが、配送タスクが追従できる前提で
+        // バースト耐性として余裕をもったキュー長を確保する
+        tickQueue = xQueueCreate(64, sizeof(TickInfo));
+        if (tickQueue == nullptr)
+        {
+            ESP_LOGE(TEMPO_LOG_TAG, "Failed to create tick queue");
+            return;
+        }
+    }
+
+    if (dispatchTask == nullptr)
+    {
+        // 発音処理 (Pipeline.sendNotes → サンプラー NoteOn) を安全に実行できるよう
+        // 十分なスタック (8192) を与える。Tmr Svc(2048) ではオーバーフローしていた。
+        BaseType_t ok = xTaskCreate(
+            dispatchTaskEntry,
+            "TempoTick",
+            8192,
+            this,
+            2, // 発音の遅延を抑えるため Arduino loopTask/audioLoop(prio1) より一段高く
+            &dispatchTask);
+        if (ok != pdPASS)
+        {
+            ESP_LOGE(TEMPO_LOG_TAG, "Failed to create dispatch task");
+            dispatchTask = nullptr;
+        }
+    }
+}
+
+void TempoController::dispatchTaskEntry(void *arg)
+{
+    static_cast<TempoController *>(arg)->dispatchLoop();
+}
+
+void TempoController::dispatchLoop()
+{
+    TickInfo info;
+    for (;;)
+    {
+        if (xQueueReceive(tickQueue, &info, portMAX_DELAY) != pdTRUE) continue;
+
+        std::list<TempoCallbacks *> listenersCopy;
+        portENTER_CRITICAL(&mutex);
+        listenersCopy = listeners;
+        portEXIT_CRITICAL(&mutex);
+
+        for (TempoCallbacks *listener : listenersCopy)
+        {
+            if (listener->getTimingMask() & info.timing)
+            {
+                listener->onTick(info);
+            }
+        }
+    }
+}
+
 void TempoController::play()
 {
     if (isPlaying) return;
+    // ディスパッチ機構が未初期化なら遅延初期化する
+    begin();
+    // 前回再生時の残り tick があれば破棄してクリーンな状態で開始する
+    if (tickQueue != nullptr) xQueueReset(tickQueue);
     std::list<TempoCallbacks *> listenersCopy;
     portENTER_CRITICAL(&mutex);
     isPlaying = true;
@@ -176,6 +243,10 @@ void TempoController::stop()
     listenersCopy = listeners;
     portEXIT_CRITICAL(&mutex);
 
+    // 停止後にキューへ残った古い tick が配送されないよう破棄する。
+    // (この時点で timerWorkInner は isPlaying=false により新規 enqueue しない)
+    if (tickQueue != nullptr) xQueueReset(tickQueue);
+
     for (TempoCallbacks *listener : listenersCopy)
     {
         listener->onPlayingStateChanged(false);
@@ -189,7 +260,6 @@ void TempoController::timerWorkInner()
     TickInfo fires[MAX_FIRES];
     size_t numFires = 0;
     bool overflow = false;
-    std::list<TempoCallbacks *> listenersCopy;
 
     portENTER_CRITICAL(&mutex);
     if (!isPlaying)
@@ -252,7 +322,6 @@ void TempoController::timerWorkInner()
         overflow = true;
     }
 
-    listenersCopy = listeners;
     portEXIT_CRITICAL(&mutex);
 
     if (overflow)
@@ -260,14 +329,18 @@ void TempoController::timerWorkInner()
         ESP_LOGW(TEMPO_LOG_TAG, "Tick poll overflow, forced resync to mt=%d", (int)now);
     }
 
-    for (size_t j = 0; j < numFires; j++)
+    // 発火した TickInfo をキューへ積むだけにする。
+    // 実際の onTick 配送 (発音などの重い処理) は専用タスク dispatchLoop が
+    // 十分なスタック上で行う。これにより Tmr Svc タスクのスタックを消費しない。
+    if (tickQueue != nullptr)
     {
-        const TickInfo &info = fires[j];
-        for (TempoCallbacks *listener : listenersCopy)
+        for (size_t j = 0; j < numFires; j++)
         {
-            if (listener->getTimingMask() & info.timing)
+            if (xQueueSend(tickQueue, &fires[j], 0) != pdTRUE)
             {
-                listener->onTick(info);
+                // 配送タスクが追従できずキューが溢れた場合は破棄する。
+                // (ここでブロックすると Tmr Svc を止めてしまうため待たない)
+                droppedTicks++;
             }
         }
     }

--- a/src/Tempo.h
+++ b/src/Tempo.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <freertos/FreeRTOS.h>
 #include <freertos/timers.h>
+#include <freertos/queue.h>
+#include <freertos/task.h>
 #include <list>
 #include <cstdint>
 #include "Foundation/MusicalTime.h"
@@ -71,6 +73,10 @@ public:
         return isPlaying;
     }
 
+    // Tick ディスパッチ用タスク／キューを初期化する (setup() から一度だけ呼ぶ)
+    // play() 内でも未初期化なら遅延初期化されるため、明示呼び出しは必須ではない
+    void begin();
+
     // テンポカウントを開始する
     void play();
 
@@ -109,6 +115,14 @@ private:
     std::list<TempoCallbacks *> listeners;
     TimerHandle_t timer = nullptr;
 
+    // Tick の重い処理 (発音など) を Tmr Svc タスクから切り離すための仕組み。
+    // timerWorkInner() は発火した TickInfo をキューへ積むだけにし、
+    // 十分なスタックを持つ専用タスク (dispatchLoop) がキューを受けて onTick を実行する。
+    QueueHandle_t tickQueue = nullptr;
+    TaskHandle_t dispatchTask = nullptr;
+    // 配送タスクが追従できずキューが溢れて破棄した tick の累計 (診断用)
+    volatile uint32_t droppedTicks = 0;
+
     // ウォールクロックアンカー
     int64_t realTimeBase = 0;           // 最後のアンカー時の esp_timer_get_time() (μs)
     musical_time_t musicalTimeBase = 0; // 最後のアンカー時点での累積 musical_time
@@ -145,6 +159,10 @@ private:
 
     void timerWorkInner();
     static void timerWork(TimerHandle_t t);
+
+    // 専用タスク: tickQueue から TickInfo を受け取りリスナーへ onTick を配送する
+    void dispatchLoop();
+    static void dispatchTaskEntry(void *arg);
 };
 
 extern TempoController Tempo;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -166,6 +166,10 @@ void setup() {
   // 保存された出力先を初期化（不正値は initializeOutput 内で Internal にフォールバック）
   Output.initializeOutput(static_cast<OutputType>(Settings.output.outputTarget.get()));
 
+  // Tempo の Tick 配送タスク／キューを初期化する。
+  // これ以降に登録される onTick リスナーは、Tmr Svc ではなく専用タスク上で実行される。
+  Tempo.begin();
+
   // PlayScreen UI の初期化（内部でコード/テンポのコールバックも登録される）
   playScreen.create();
 


### PR DESCRIPTION
1msソフトウェアタイマーのコールバックは「Tmr Svc」タスク(スタック2048B)上で実行されるが、そこから onTick → Pipeline.sendNotes → サンプラー NoteOn という深い同期チェーンを直接呼んでいたためスタックオーバーフローでクラッシュしていた。 timerWorkInner は発火した TickInfo をキューに積むだけにし、十分なスタック(8192B)を持つ専用タスク TempoTick が配送・発音を行うように変更する。 play()/stop() でキューをリセットし、停止後に古い tick が配送されないようにする。