### PR TITLE
スピーカーの音量を小さく修正

### DIFF
--- a/src/Output/OutputInternal.cpp
+++ b/src/Output/OutputInternal.cpp
@@ -271,9 +271,9 @@ void OutputInternal::initAudioOutput(AudioOutput output)
         aw88298_write_reg(0x05, 0x0008); // RMSE=0 HAGCE=0 HDCCE=0 HMUTE=0
         aw88298_write_reg(0x06, reg0x06_value);
         // aw88298_write_reg(0x0C, 0x0064);  // volume setting (full volume)
-        aw88298_write_reg(0x0C, 0x1064); // volume setting (-6db)
+        // aw88298_write_reg(0x0C, 0x1064); // volume setting (-6db)
         // aw88298_write_reg(0x0C, 0x1664); // volume setting (-9db)
-        // aw88298_write_reg(0x0C, 0x2064); // volume setting (-12db)
+        aw88298_write_reg(0x0C, 0x2064); // volume setting (-12db)
         esp_pinMode(PIN_EN_HP, GPIO_MODE_OUTPUT);
         esp_digitalWrite(PIN_EN_HP, 0);
     }

--- a/src/SettingsStore.cpp
+++ b/src/SettingsStore.cpp
@@ -146,7 +146,7 @@ void VoicingSettings::deserializeItems(InputArchive& archive) {
 OutputSettings::OutputSettings(SettingsStore* store)
     : SettingsCategoryBase("/settings/output.json"),
       outputTarget("outputTarget", 0, &isDirty, store),
-      speakerVolume("speakerVolume", 23, &isDirty, store),
+      speakerVolume("speakerVolume", 29, &isDirty, store),
       headphoneVolume("headphoneVolume", 23, &isDirty, store),
       timbreId("timbreId", std::string("piano"), &isDirty, store) {}
 


### PR DESCRIPTION
AW88298の音量設定を-6dbから-12dbに変更する代わりに、スピーカー音量の初期設定を23から29に変更 これにより初期状態でのスピーカー音量は変化しないが、設定できる最大の音量が小さくなる